### PR TITLE
Use bgpd and zebra sockets to collect bgp metrics

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -95,7 +95,7 @@ func (e *Exporters) Collect(ch chan<- prometheus.Metric) {
 	wg := &sync.WaitGroup{}
 	for _, collector := range e.Collectors {
 		wg.Add(1)
-		go runCollector(ch, errCh, collector, wg)
+		runCollector(ch, errCh, collector, wg)
 	}
 	wg.Wait()
 


### PR DESCRIPTION
Use `bgpd.vty` and `zebra.vty` sockets to collect metrics as it greatly reduces scrape daration (1.5sec -> 0.0015sec).

I had to remove concurrency as it reduces reliability when reading from the socket directly. Sometimes when too many clients try to open socket it returns an error. It doesn't have a big impact on scrape duration as it is still acceptable.

@vinted/sre 