### PR TITLE
Add mutex on socket write and reenable concurrency

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -95,7 +95,7 @@ func (e *Exporters) Collect(ch chan<- prometheus.Metric) {
 	wg := &sync.WaitGroup{}
 	for _, collector := range e.Collectors {
 		wg.Add(1)
-		runCollector(ch, errCh, collector, wg)
+		go runCollector(ch, errCh, collector, wg)
 	}
 	wg.Wait()
 


### PR DESCRIPTION
This should reduce scrape time even more and ensure no two routines write to socket at the same time.

@vinted/sre 